### PR TITLE
Ausgabe-XML-Datei-Name mit Bezug zum Namen der CSV-Datei

### DIFF
--- a/MoodleQuizGenerator/ModelXML.cs
+++ b/MoodleQuizGenerator/ModelXML.cs
@@ -13,6 +13,7 @@ namespace MoodleQuizGenerator
         private IController controller;
         private IView view;
         private string path="dasIsteinTest.xml";
+        public string Path { get => path; set => path = value; }
         IController IModel.Controller { set => controller = value; }
         IView IModel.View { set => view = value; }
 

--- a/MoodleQuizGenerator/Program.cs
+++ b/MoodleQuizGenerator/Program.cs
@@ -31,6 +31,9 @@ namespace MoodleQuizGenerator
             }
             List<Quizfrage> quizfragen = modelCSV.suchen(new Quizfrage("", "", "", "", "", "", "", "", "", "", "", ""), praefix);
 
+            // Dateiname der XML-Datei-Ausgabe mit klarem Bezug versehen
+            (modelXML as ModelXML).Path = praefix + ".xml";
+
             foreach (Quizfrage quizfrage in quizfragen)
             {
                 modelXML.speichern(quizfrage);


### PR DESCRIPTION
Ein kleiner erster Versuch den Beispielnamen der .xml-Datei mehr an den aktuellen Präfix anzupassen und um den Workflow für die Entwicklung des Projekts zu testen