### PR TITLE
Dev Variable Anzahl Antworten

### DIFF
--- a/MoodleQuizGenerator/IModel.cs
+++ b/MoodleQuizGenerator/IModel.cs
@@ -7,7 +7,7 @@
 
         void speichern(Quizfrage quizfrage);
         List<Quizfrage> suchen(Quizfrage quizfrage);
-        List<Quizfrage> suchen(Quizfrage quizfrage, string praefix);
+        List<Quizfrage> suchen(Quizfrage quizfrage, string praefix, bool anzahlFragenFix);
         void loeschen(Quizfrage quizfrage);
     }
 }

--- a/MoodleQuizGenerator/Kommandozeilenargumente.cs
+++ b/MoodleQuizGenerator/Kommandozeilenargumente.cs
@@ -1,0 +1,44 @@
+﻿namespace MoodleQuizGenerator
+{
+    // ACHTUNG: Eine Klasse mit KI erzeugt, mit der man
+    // Kommandozeilenargumente organisieren kann.
+    // Hier muss besonders viel kontrolliert werden.
+    class Kommandozeilenargumente
+    {
+        public string[] Argumente { get; private set; }
+        public Kommandozeilenargumente(string[] args)
+        {
+            Argumente = args;
+        }
+
+        public string HoleArgument(string argument)
+        {
+            for (int i = 0; i < Argumente.Length; i++)
+            {
+                if (Argumente[i] == argument)
+                {
+                    if (i + 1 < Argumente.Length)
+                    {
+                        return Argumente[i + 1];
+                    }
+                    else
+                    {
+                        throw new ArgumentException("Fehlendes Argument für " + argument);
+                    }
+                }
+            }
+            throw new ArgumentException("Argument " + argument + " nicht gefunden");
+        }
+        public bool IstArgumentVorhanden(string argument)
+        {
+            for (int i = 0; i < Argumente.Length; i++)
+            {
+                if (Argumente[i] == argument)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/MoodleQuizGenerator/ModelCSV.cs
+++ b/MoodleQuizGenerator/ModelCSV.cs
@@ -55,6 +55,14 @@
                         {
                             continue;
                         }
+
+                        if (subs.Length < 6)
+                        {
+                            Console.WriteLine("Mindestanzahl von 6 Eintraegen pro Zeile nicht gegeben in Datei: "
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
                         if (subs[0] == "")
                         {
                             Console.WriteLine("Fragennummer fehlt in Datei: " 

--- a/MoodleQuizGenerator/ModelCSV.cs
+++ b/MoodleQuizGenerator/ModelCSV.cs
@@ -15,10 +15,10 @@
             throw new NotImplementedException();
         }
 
-        List<Quizfrage> IModel.suchen(Quizfrage quizfrage, string praefix)
+        List<Quizfrage> IModel.suchen(Quizfrage quizfrage, string praefix, bool anzahlFragenFix)
         {
             List<Quizfrage> ergebnis= new List<Quizfrage>();
-            Quizfrage treffer = new Quizfrage("", "", "", "", "", "", "", "", "", "", "", "");
+            Quizfrage treffer;
 
             try
             {
@@ -39,8 +39,10 @@
                         }
                     }
 
+                    int lineNumber = 0;
                     foreach (string line in list)
                     {
+                        lineNumber++;
                         // Mit einem Backslash maskierte Semikola bearbeiten
                         string alteredLine=line.Replace("\\;", "&semicolon&");
                         string[] subs = alteredLine.Split(';');
@@ -48,118 +50,201 @@
                         {
                             subs[i]=subs[i].Replace("&semicolon&", ";");
                         }
-                        
-                        int number = 0;
-                        treffer = new Quizfrage("", "", "", "", "", "", "", "", "", "", "", "");
-                        if (subs.Length == 12)
+
+                        if (subs[0] == "Nr." || subs[0] == "Nr" || subs[0] == "Nummer" || subs[0] == "NR." || subs[0] == "NR")
                         {
-                            if (int.TryParse(subs[0], out number))
+                            continue;
+                        }
+                        if (subs[0] == "")
+                        {
+                            Console.WriteLine("Fragennummer fehlt in Datei: " 
+                                + dateiname + " in Zeile "+ Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        int number;
+                        if (int.TryParse(subs[0], out number)==false)
+                        {
+                            Console.WriteLine("Erster Eintrag in einer Zeile ist keine Fragennummer: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            //continue;
+                        }
+
+                        if (subs[1] == "")
+                        {
+                            Console.WriteLine("Frage fehlt in einer Zeile der Datei: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        if((dateiname.Split(praefix)).Length <= 1)
+                        {
+                            Console.WriteLine("Dateiname ist nicht korrekt: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        if (anzahlFragenFix == true)
+                        {
+                            if (subs.Length == 12)
                             {
-                                if (subs[0]!=""
-                                    && subs[1] != ""
-                                    && subs[2] != ""
-                                    && subs[3] != ""
-                                    && subs[4] != ""
-                                    && subs[5] != ""
-                                    && subs[6] != ""
-                                    && subs[7] != ""
-                                    && subs[8] != ""
-                                    && subs[9] != ""
-                                    && subs[10] != ""
-                                    && subs[11] != ""
-                                    ) {
-                                    int rcount = 0;
-                                    string fractionR = "0";
-                                    string fractionF = "0";
 
-                                    treffer.Fragennummer = subs[0];
-                                    treffer.Frage = subs[1];
-                                    treffer.Antwort1 = subs[2];
-                                    if (subs[3].ToUpper() == "R")
-                                        rcount++;
-                                    treffer.Antwort2 = subs[4];
-                                    if (subs[5].ToUpper() == "R")
-                                        rcount++;
-                                    treffer.Antwort3 = subs[6];
-                                    if (subs[7].ToUpper() == "R")
-                                        rcount++;
-                                    treffer.Antwort4 = subs[8];
-                                    if (subs[9].ToUpper() == "R")
-                                        rcount++;
-                                    treffer.Antwort5 = subs[10];
-                                    if (subs[11].ToUpper() == "R")
-                                        rcount++;
-
-                                    fractionR = Convert.ToString(
-                                                                    Math.Round(
-                                                                                (100 / Convert.ToDouble(rcount))
-                                                                                , 5
-                                                                               )
-                                                                    , new System.Globalization.CultureInfo("en-US")
-                                                                );
-                                    fractionF = Convert.ToString(
-                                                                    Math.Round(
-                                                                                ((double)-100.0 / ((double)5.0 - Convert.ToDouble(rcount)))
-                                                                                , 5
-                                                                                )
-                                                                    , new System.Globalization.CultureInfo("en-US")
-
-                                                                );
-
-                                    if (subs[3].ToUpper() == "R")
-                                        treffer.Fraction1 = fractionR;
-                                    else
-                                        treffer.Fraction1 = fractionF;
-                                    if (subs[5].ToUpper() == "R")
-                                        treffer.Fraction2 = fractionR;
-                                    else
-                                        treffer.Fraction2 = fractionF;
-                                    if (subs[7].ToUpper() == "R")
-                                        treffer.Fraction3 = fractionR;
-                                    else
-                                        treffer.Fraction3 = fractionF;
-                                    if (subs[9].ToUpper() == "R")
-                                        treffer.Fraction4 = fractionR;
-                                    else
-                                        treffer.Fraction4 = fractionF;
-                                    if (subs[11].ToUpper() == "R")
-                                        treffer.Fraction5 = fractionR;
-                                    else
-                                        treffer.Fraction5 = fractionF;
-
-
-                                    ergebnis.Add(treffer);
+                                bool subsNotEmpty = true;
+                                for(int i = 2; i < 12; i++)
+                                {
+                                    if (subs[i] == "") subsNotEmpty = false;
                                 }
-                                else {
-                                    if ((dateiname.Split(praefix)).Length > 1)
-                                    {
-                                        Console.WriteLine((dateiname.Split(praefix)[1]).Split(".csv")[0] +
-                                            " wie wäre es mit Inhalt?");
-                                    }
-                                    else
-                                    {
-                                        Console.WriteLine("Was ist das denn?? Weder Inhalt noch Dateiname richtig!");
-                                        Console.WriteLine(dateiname);
-                                    }
+                                if(subsNotEmpty==false){
+                                    Console.WriteLine("Inhalt fehlt in einer Zeile der Datei: " 
+                                        + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                Console.WriteLine("Falsche Anzahl an Argumenten(" + subs.Length + ") in Datei "
+                                    + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            }
+                        }
+
+                        if (subs.Length % 2 != 0)
+                        {
+                            Console.WriteLine("Ungerade Anzahl an Einträgen in einer Zeile der Datei: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+                 
+                        bool zweierPaareKonsistent = true;
+                        int anzahlSubsPaareGefuellt = 1;
+                        for(int i = 0; i < subs.Length / 2 - 1; i++)
+                        {
+                            if (subs[2 * (i + 1)] == "")
+                            {
+                                if (subs[2 * (i + 1)+1] != "")
+                                {
+                                    zweierPaareKonsistent = false;
+                                }
+                            }
+                            if (subs[2 * (i + 1)] != "")
+                            {
+                                if (subs[2 * (i + 1) + 1] == "")
+                                {
+                                    zweierPaareKonsistent = false;
+                                }
+                                else
+                                {
+                                    anzahlSubsPaareGefuellt++;
                                 }
                             }
                         }
-                        else
-                        {
-                           
-                            try
-                            {
-                                Console.Write((dateiname.Split(praefix)[1]).Split(".csv")[0]);
 
-                                Console.WriteLine(" Incorrect length(" + subs.Length + ") in file");// + dateiname);
-                                                                                                   //Console.WriteLine("Length:"+);
-                            }
-                            catch(Exception exc)
+                        if (anzahlSubsPaareGefuellt <3)
+                        {
+                            Console.WriteLine("Zu wenige Antworten in einer Zeile der Datei: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        if (zweierPaareKonsistent == false)
+                        {
+                            Console.WriteLine("Mindestens ein Antwort/Richtig-Oder-Falsch-Paar ist nicht konsistent in einer Zeile der Datei: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        bool mindestensEineRichtigeAntwort = false;
+                        bool mindestensEineFalscheAntwort = false;
+                        for (int i = 0; i < subs.Length / 2 - 1; i++)
+                        {
+                            if (subs[2 * (i + 1) + 1].ToUpper() == "R")
                             {
-                                Console.WriteLine("Weder Länge noch Name der Datei stimmt:");
-                                Console.WriteLine(dateiname);
+                                mindestensEineRichtigeAntwort = true;
+                            }
+                            if (subs[2 * (i + 1) + 1].ToUpper() == "F")
+                            {
+                                mindestensEineFalscheAntwort = true;
                             }
                         }
+                        if (mindestensEineRichtigeAntwort==false || mindestensEineFalscheAntwort==false)
+                        {
+                            Console.WriteLine("In einer Zeile fehlt mindestens eine richtige und mindestens eine falsche Antwort in der Datei: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        bool antwortenRichtigOderFalsch=true;
+                        for (int i = 0; i < subs.Length / 2 - 1; i++)
+                        {
+                            if(subs[2 * (i + 1) + 1] != "")
+                            {
+                                if (subs[2 * (i + 1) + 1].ToUpper() != "R" && subs[2 * (i + 1) + 1].ToUpper() != "F")
+                                {
+                                    antwortenRichtigOderFalsch = false;
+                                }
+                            }
+                        }
+                        if (antwortenRichtigOderFalsch == false)
+                        {
+                            Console.WriteLine("In einer Zeile sind nicht alle Antworten als richtig oder falsch markiert in der Datei: " 
+                                + dateiname + " in Zeile " + Convert.ToString(lineNumber));
+                            continue;
+                        }
+
+                        int rcount = 0;
+                        int acount = 0;
+
+                        string fractionR = "0";
+                        string fractionF = "0";
+
+                        treffer = new Quizfrage("", "", new List<string>(), new List<string>());
+                        treffer.Fragennummer = subs[0];
+                        treffer.Frage = subs[1];
+
+                        for (int i = 2; i < subs.Length; i += 2)
+                        {
+                            if(subs[i] != "")
+                            {
+                                if (subs[i + 1].ToUpper() == "R")
+                                {
+                                    rcount++;
+                                }
+                                acount++;
+                            }
+                        }
+
+                        fractionR = Convert.ToString(
+                                                        Math.Round(
+                                                                    (100 / Convert.ToDouble(rcount))
+                                                                    , 5
+                                                                    )
+                                                        , new System.Globalization.CultureInfo("en-US")
+                                                    );
+                        fractionF = Convert.ToString(
+                                                        Math.Round(
+                                                                    ((double)-100.0 / ((double)acount - Convert.ToDouble(rcount)))
+                                                                    , 5
+                                                                    )
+                                                        , new System.Globalization.CultureInfo("en-US")
+                                                    );
+
+                        for (int i = 2; i < subs.Length; i += 2)
+                        {
+                            if (subs[i] != "")
+                            {
+                                treffer.Antworten.Add(subs[i]);
+                                if (subs[i + 1].ToUpper() == "R")
+                                {
+                                    treffer.Fractions.Add(fractionR);
+                                }
+                                else
+                                {
+                                    treffer.Fractions.Add(fractionF);
+                                }
+                                treffer.AnzahlAntworten++;
+                            }
+                        }
+
+                        ergebnis.Add(treffer);     
                     }
                 }
 

--- a/MoodleQuizGenerator/ModelXML.cs
+++ b/MoodleQuizGenerator/ModelXML.cs
@@ -13,9 +13,13 @@ namespace MoodleQuizGenerator
         private IController controller;
         private IView view;
         private string path="dasIsteinTest.xml";
+        private string penalty= "0.0000000";
+        private string defaultgrade = "5.0000000";
         public string Path { get => path; set => path = value; }
         IController IModel.Controller { set => controller = value; }
         IView IModel.View { set => view = value; }
+        public string Penalty { get => penalty; set => penalty = value; }
+        public string Defaultgrade { get => defaultgrade; set => defaultgrade = value; }
 
         void IModel.loeschen(Quizfrage quizfrage)
         {
@@ -24,8 +28,6 @@ namespace MoodleQuizGenerator
 
         void IModel.speichern(Quizfrage quizfrage)
         {
-            
-
             XComment com = new XComment("question: "+quizfrage.Fragennummer);
             XElement element = new XElement("question",
                 new XAttribute("type" , "multichoice"),
@@ -39,8 +41,8 @@ namespace MoodleQuizGenerator
                 new XElement("generalfeedback",
                     new XAttribute("format", "html"),
                 new XElement("text")),
-            new XElement("defaultegrade", "1.0000000"),
-            new XElement("penalty","0.0000000"),
+            new XElement("defaultegrade", Defaultgrade),
+            new XElement("penalty", penalty),
             new XElement("hidden","0"),
             new XElement("idnumber"),
             new XElement("single","false"),
@@ -75,8 +77,6 @@ namespace MoodleQuizGenerator
             doc.Element("quiz").Add(com);
             doc.Element("quiz").Add(element);
             doc.Save(path);
-
-
         }
 
         List<Quizfrage> IModel.suchen(Quizfrage quizfrage)
@@ -117,17 +117,6 @@ namespace MoodleQuizGenerator
             //{
                 string nameKategorie = "HabIchMirAusgedacht";
                 defineInitialXElement(nameKategorie);
-                /*doc = new XDocument(new XElement("quiz",
-                    new XComment("question: 0"),
-                    new XElement("question",
-                        new XAttribute ("type","category"),
-                        new XElement("category",
-                            new XElement("text","$course$/top/"+nameKategorie)),
-                        new XElement("info",
-                            new XAttribute("format","moodle_auto_format"),
-                            new XElement("text","Standardkategorie für Fragen, die im Kontext 'Ausdenken' freigegeben sind.")),
-                        new XElement("idnumber"))));*/
-            //}
         }
 
         public void defineInitialXElement(string nameKategorie)

--- a/MoodleQuizGenerator/ModelXML.cs
+++ b/MoodleQuizGenerator/ModelXML.cs
@@ -116,7 +116,8 @@ namespace MoodleQuizGenerator
             //else
             //{
                 string nameKategorie = "HabIchMirAusgedacht";
-                doc = new XDocument(new XElement("quiz",
+                defineInitialXElement(nameKategorie);
+                /*doc = new XDocument(new XElement("quiz",
                     new XComment("question: 0"),
                     new XElement("question",
                         new XAttribute ("type","category"),
@@ -125,8 +126,22 @@ namespace MoodleQuizGenerator
                         new XElement("info",
                             new XAttribute("format","moodle_auto_format"),
                             new XElement("text","Standardkategorie für Fragen, die im Kontext 'Ausdenken' freigegeben sind.")),
-                        new XElement("idnumber"))));
+                        new XElement("idnumber"))));*/
             //}
+        }
+
+        public void defineInitialXElement(string nameKategorie)
+        {
+            doc = new XDocument(new XElement("quiz",
+                new XComment("question: 0"),
+                new XElement("question",
+                    new XAttribute("type", "category"),
+                    new XElement("category",
+                        new XElement("text", "$course$/top/" + nameKategorie)),
+                    new XElement("info",
+                        new XAttribute("format", "moodle_auto_format"),
+                        new XElement("text", "Standardkategorie für Fragen, die im Kontext 'Ausdenken' freigegeben sind.")),
+                    new XElement("idnumber"))));
         }
     }
 }

--- a/MoodleQuizGenerator/ModelXML.cs
+++ b/MoodleQuizGenerator/ModelXML.cs
@@ -39,7 +39,7 @@ namespace MoodleQuizGenerator
                 new XElement("generalfeedback",
                     new XAttribute("format", "html"),
                 new XElement("text")),
-            new XElement("defaultegrade", "5.0000000"),
+            new XElement("defaultegrade", "1.0000000"),
             new XElement("penalty","0.0000000"),
             new XElement("hidden","0"),
             new XElement("idnumber"),
@@ -56,57 +56,22 @@ namespace MoodleQuizGenerator
             new XElement("incorrectfeedback",
                 new XAttribute("format","html"),
                 new XElement("text","Die Antwort ist falsch.")),
-            new XElement("shownumcorrect"),
-            
-            new XElement("answer",
-                new XAttribute("fraction",quizfrage.Fraction1),
-                new XAttribute("format","html"),
-                new XElement("text",
-                    new XCData("<p dir=\"ltr\" style=\"text-align: left;\">" +
-                        quizfrage.Antwort1+"</p>")),
-                new XElement("feedback",
-                    new XAttribute("format","html"),
-                    new XElement("text"))),
-            
-            new XElement("answer",
-                new XAttribute("fraction",quizfrage.Fraction2),
-                new XAttribute("format", "html"),
-                new XElement("text", 
-                    new XCData("<p dir=\"ltr\" style=\"text-align: left;\">" +
-                        quizfrage.Antwort2+"</p>")),
-                new XElement("feedback",
-                    new XAttribute("format", "html"),
-                    new XElement("text"))),
-
-            new XElement("answer",
-                new XAttribute("fraction",quizfrage.Fraction3),
-                new XAttribute("format", "html"),
-                new XElement("text", 
-                    new XCData("<p dir=\"ltr\" style=\"text-align: left;\">" +
-                        quizfrage.Antwort3+"</p>")),
-                new XElement("feedback",
-                    new XAttribute("format", "html"),
-                    new XElement("text"))),
-            new XElement("answer",
-                new XAttribute("fraction",quizfrage.Fraction4),
-                new XAttribute("format", "html"),
-                new XElement("text",
-                    new XCData("<p dir=\"ltr\" style=\"text-align: left;\">" +
-                        quizfrage.Antwort4+"</p>")),
-                new XElement("feedback",
-                    new XAttribute("format", "html"),
-                    new XElement("text"))),
-            new XElement("answer",
-                new XAttribute("fraction",quizfrage.Fraction5),
-                new XAttribute("format", "html"),
-                new XElement("text", 
-                    new XCData("<p dir = \"ltr\" style=\"text-align: left;\">" +
-                        quizfrage.Antwort5+"</p>")),
-                new XElement("feedback",
-                    new XAttribute("format", "html"),
-                    new XElement("text")))
-                   
+            new XElement("shownumcorrect")
                 );
+
+            for(int i = 0; i < quizfrage.AnzahlAntworten; i++)
+            {
+                element.Add(new XElement("answer",
+                    new XAttribute("fraction", quizfrage.Fractions[i]),
+                    new XAttribute("format", "html"),
+                    new XElement("text",
+                        new XCData("<p dir = \"ltr\" style=\"text-align: left;\">" +
+                            quizfrage.Antworten[i] + "</p>")),
+                    new XElement("feedback",
+                        new XAttribute("format", "html"),
+                        new XElement("text"))));
+            }
+
             doc.Element("quiz").Add(com);
             doc.Element("quiz").Add(element);
             doc.Save(path);
@@ -130,12 +95,12 @@ namespace MoodleQuizGenerator
 
             //view.anzeigen(erList);
             List<Quizfrage> ergebnis=new List<Quizfrage>();
-            ergebnis.Add(new Quizfrage("", "", "", "", "", "", "", "", "", "", "", ""));
+            ergebnis.Add(new Quizfrage("", "", new List<string>(), new List<string>()));
             return ergebnis;
 
         }
 
-        List<Quizfrage> IModel.suchen(Quizfrage quizfrage, string praefix)
+        List<Quizfrage> IModel.suchen(Quizfrage quizfrage, string praefix, bool anzahlFragenFix)
         {
             throw new NotImplementedException();
         }

--- a/MoodleQuizGenerator/MoodleQuizGenerator.csproj
+++ b/MoodleQuizGenerator/MoodleQuizGenerator.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 
 </Project>

--- a/MoodleQuizGenerator/Program.cs
+++ b/MoodleQuizGenerator/Program.cs
@@ -19,17 +19,31 @@ namespace MoodleQuizGenerator
 
             string praefix = "Aufgabe";
 
-            if (args.Length > 0)
+            // ACHTUNG: Diese Klasse ist rein mit KI erzeugt.
+            Kommandozeilenargumente kommandozeilenargumente = new Kommandozeilenargumente(args);
+
+            // Kommandozeilenargument fuer die Abfrage, ob die Anzahl an Quizfragen festgelegt wurde
+            bool anzahlFragenFix = true;
+            if (kommandozeilenargumente.IstArgumentVorhanden("-f"))
             {
-                Console.WriteLine("Suche nach Dateien mit Praefix:" + args[0]);
-                praefix = args[0];
+                string anzahlFragenFixStr = kommandozeilenargumente.HoleArgument("-f");
+                if (anzahlFragenFixStr.ToLower() == "false")
+                {
+                    anzahlFragenFix = false;
+                }
+            }
+
+            if (kommandozeilenargumente.IstArgumentVorhanden("-p"))
+            {
+                praefix = kommandozeilenargumente.HoleArgument("-p");
+                Console.WriteLine("Suche nach Dateien mit Praefix:" + praefix);
             }
             else
             {
                 Console.Write("Praefix: ");
                 praefix = Console.ReadLine();
             }
-            List<Quizfrage> quizfragen = modelCSV.suchen(new Quizfrage("", "", "", "", "", "", "", "", "", "", "", ""), praefix);
+            List<Quizfrage> quizfragen = modelCSV.suchen(new Quizfrage("", "", new List<string>(), new List<string>()), praefix, anzahlFragenFix);
 
             // Dateiname der XML-Datei-Ausgabe mit klarem Bezug versehen
             (modelXML as ModelXML).Path = praefix + ".xml";

--- a/MoodleQuizGenerator/Program.cs
+++ b/MoodleQuizGenerator/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Xml.Linq;
 
 namespace MoodleQuizGenerator
 {
@@ -47,6 +48,9 @@ namespace MoodleQuizGenerator
 
             // Dateiname der XML-Datei-Ausgabe mit klarem Bezug versehen
             (modelXML as ModelXML).Path = praefix + ".xml";
+
+            // Kategoriename gleichsetzen mit dem Praefix
+            (modelXML as ModelXML).defineInitialXElement(praefix);
 
             foreach (Quizfrage quizfrage in quizfragen)
             {

--- a/MoodleQuizGenerator/Program.cs
+++ b/MoodleQuizGenerator/Program.cs
@@ -44,6 +44,20 @@ namespace MoodleQuizGenerator
                 Console.Write("Praefix: ");
                 praefix = Console.ReadLine();
             }
+
+            if (kommandozeilenargumente.IstArgumentVorhanden("-y"))
+            {
+                string penalty = kommandozeilenargumente.HoleArgument("-y");
+                (modelXML as ModelXML).Penalty = penalty;
+            }
+
+            if (kommandozeilenargumente.IstArgumentVorhanden("-g"))
+            {
+                string defaultgrade = kommandozeilenargumente.HoleArgument("-g");
+                (modelXML as ModelXML).Defaultgrade = defaultgrade;
+            }
+
+
             List<Quizfrage> quizfragen = modelCSV.suchen(new Quizfrage("", "", new List<string>(), new List<string>()), praefix, anzahlFragenFix);
 
             // Dateiname der XML-Datei-Ausgabe mit klarem Bezug versehen

--- a/MoodleQuizGenerator/Properties/launchSettings.json
+++ b/MoodleQuizGenerator/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "MoodleQuizGenerator": {
       "commandName": "Project",
-      "commandLineArgs": "QuizAufgabenBS"
+      "commandLineArgs": "-p QuizAufgaben -f false"
     }
   }
 }

--- a/MoodleQuizGenerator/Properties/launchSettings.json
+++ b/MoodleQuizGenerator/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "MoodleQuizGenerator": {
       "commandName": "Project",
-      "commandLineArgs": "-p QuizAufgaben -f false"
+      "commandLineArgs": "-p QuizAufgaben -f false -y 1 -g 1.00000"
     }
   }
 }

--- a/MoodleQuizGenerator/Quizfrage.cs
+++ b/MoodleQuizGenerator/Quizfrage.cs
@@ -4,49 +4,29 @@
     {
         private string fragennummer;
         private string frage;
-        private string antwort1;
-        private string fraction1;
-        private string antwort2;
-        private string fraction2;
-        private string antwort3;
-        private string fraction3;
-        private string antwort4;
-        private string fraction4;
-        private string antwort5;
-        private string fraction5;
+        private List<string> fractions;
+        private List<string> antworten;
+        int anzahlAntworten;
 
         public string Fragennummer { get => fragennummer; set => fragennummer = value; }
         public string Frage { get => frage; set => frage = value; }
-        public string Antwort1 { get => antwort1; set => antwort1 = value; }
-        public string Fraction1 { get => fraction1; set => fraction1 = value; }
-        public string Antwort2 { get => antwort2; set => antwort2 = value; }
-        public string Fraction2 { get => fraction2; set => fraction2 = value; }
-        public string Antwort3 { get => antwort3; set => antwort3 = value; }
-        public string Fraction3 { get => fraction3; set => fraction3 = value; }
-        public string Antwort4 { get => antwort4; set => antwort4 = value; }
-        public string Fraction4 { get => fraction4; set => fraction4 = value; }
-        public string Antwort5 { get => antwort5; set => antwort5 = value; }
-        public string Fraction5 { get => fraction5; set => fraction5 = value; }
+        public List<string> Antworten { get => antworten; set => antworten = value; }
+        public List<string> Fractions { get => fractions; set => fractions = value; }
+        public int AnzahlAntworten { get => anzahlAntworten; set => anzahlAntworten = value; }
+
 
         public Quizfrage(string fragennummer,string frage,
-                            string antwort1,string fraction1,
-                            string antwort2, string fraction2,
-                            string antwort3, string fraction3,
-                            string antwort4, string fraction4,
-                            string antwort5, string fraction5)
+                         List<string> fractions, List<string> antworten)
         {
             Fragennummer=fragennummer;
             Frage = frage;
-            Antwort1=antwort1;
-            Antwort2=antwort2;
-            Antwort3=antwort3;
-            Antwort4=antwort4;
-            Antwort5=antwort5;
-            Fraction1=fraction1;
-            Fraction2=fraction2;
-            Fraction3=fraction3;
-            Fraction4=fraction4;
-            Fraction5=fraction5;
+            Antworten = antworten;
+            Fractions = fractions;
+            if (Antworten.Count != Fractions.Count)
+            {
+                throw new ArgumentException("Anzahl der Antworten und Fractions stimmen nicht überein.");
+            }
+            AnzahlAntworten = Antworten.Count;
         }
     }
 }


### PR DESCRIPTION
Bezüglich #1 .

Die Anzahl an Antworten ist nun variabel. Es können also beliebig viele Semikola genutzt werden und Plätze zwischen den Semikola freigelassen werden. 

Weiterhin können nun zwei Argumente genutzt werden. -p "PRAEFIX STRING HIER" und -f "true/false" mit true = fixierte Anzahl an Antworten, nämlich 5, und false = variable Anzahl an Antworten. Das heißt, dass das Feature der variablen Anzahl an Antworten optional ist. Der Default ist "-f true".

Weiterhin sind noch ein paar Ausnahmen hinzugefügt worden. Zum Beispielen werden Zeilen ausgelassen, die mit Nr und ähnlichen Strings starten. Da dies die Beispielzeile einer Beispiel-CSV-Datei ist und die Lernenden diese Zeile einfach nicht löschen.

Es werden auch noch weitere Tests durchgeführt, ob die Abgabe valide ist. Es wird zum Beispiel auch kontrolliert, ob mindestens eine richtige und mindestens eine falsche Antwort abgegeben worden ist.

Viel Spaß beim Studium der Änderungen. ;)